### PR TITLE
Typescript definitions

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,0 +1,15 @@
+declare module 'react-image-webp' {
+  import React from 'react';
+  interface ImageProps {
+    src: string;
+    webp?: string;
+    alt?: string;
+    title?: string;
+    style?: { [ key: string ]: object };
+    className?: string;
+  }
+  export default class Image extends React.Component<ImageProps, any> {}
+}
+declare module 'react-image-webp/dist/utils' {
+  export function isWebpSupported(): boolean;
+}


### PR DESCRIPTION
## Issue description

There were no typescript definitions, which causes linting errors when working in VSCode on a typescript project.

## Proposed Changes

  - Wrote definitions for exported component and function.

