### PR TITLE
Update typings

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,12 +1,7 @@
 declare module 'react-image-webp' {
   import React from 'react';
-  interface ImageProps {
-    src: string;
+  interface ImageProps extends React.DetailedHTMLProps<React.ImgHTMLAttributes<HTMLImageElement>, HTMLImageElement> {
     webp?: string;
-    alt?: string;
-    title?: string;
-    style?: { [ key: string ]: object };
-    className?: string;
   }
   export default class Image extends React.Component<ImageProps, any> {}
 }


### PR DESCRIPTION
## Issue description

Simplify and extend the existing `img` props to match the code functionality

## Proposed Changes

React typing provide props for `img` tags already. We should be extending these, and adding our `webp` prop to it